### PR TITLE
v1.4.8 – Blindagem do header/footer com includes e remoção do botão de commit

### DIFF
--- a/ecossistema.html
+++ b/ecossistema.html
@@ -594,27 +594,6 @@
      </a>
    </div>
 
-   <!-- ============================================= -->
-   <!--           BOTÃO “COMMIT VALIDADO”             -->
-   <!-- ============================================= -->
-   <div style="text-align: center; margin: 1rem 0;">
-     <a href="./commit-validado.bat" download
-        style="
-          display: inline-block;
-          background-color: var(--accent);
-          color: #ffffff;
-          padding: 10px 20px;
-          border-radius: var(--radius);
-          font-weight: 600;
-          text-decoration: none;
-          transition: background-color 0.2s ease, transform 0.2s ease;
-        "
-        onmouseover="this.style.transform='scale(1.05)';"
-        onmouseout="this.style.transform='scale(1)';"
-        title="Clique para gerar commit validado">
-       Commit Validado
-     </a>
-   </div>
 
    <!-- ============================================= -->
    <!--             SCRIPT FOOTER REVEAL              -->

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="pt-br">
 <head>
-  <!-- Mantido exatamente o <head> original com metas e links -->
+  <!-- Mantido exatamente o <head> original com metas e links, incluindo meta keywords atualizadas -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Home | OLV Internacional</title>
@@ -344,20 +344,6 @@
     </a>
     <a href="contato.html" class="specialist-button" title="Fale com um Especialista OLV">
       <img src="icons/email.svg" alt="E-mail" /> Fale com um Especialista
-    </a>
-  </div>
-
-  <!-- ============================================= -->
-  <!--           BOTÃO “COMMIT VALIDADO”             -->
-  <!-- ============================================= -->
-  <div class="commit-float-container">
-    <a
-      href="./commit-validado.bat"
-      download
-      class="commit-float-button"
-      title="Clique para gerar commit validado"
-    >
-      Commit Validado
     </a>
   </div>
 


### PR DESCRIPTION
Esta PR “blinda” o site na versão 1.4.8, incluindo:
- Passagem do header e footer para os includes (header.html / footer.html)
- Remoção definitiva do botão “Commit Validado” do HTML
- Ajustes no ecossistema e atualização de CSS conforme as regras do novo Google Ads AI Mode
